### PR TITLE
[Inference] - Add half precision & HuggingFace alignment tests + Spee…

### DIFF
--- a/.github/workflows/gpu-ci-skip.yml
+++ b/.github/workflows/gpu-ci-skip.yml
@@ -40,6 +40,7 @@ jobs:
   gpu-ci-flexflow:
     name: Single Machine, Multiple GPUs Tests
     runs-on: ubuntu-20.04
+    if: ${{ github.event_name != 'pull_request' || github.base_ref != 'inference' }}
     needs: inference-tests
     steps:
       - run: 'echo "No gpu-ci required"'

--- a/.github/workflows/gpu-ci.yml
+++ b/.github/workflows/gpu-ci.yml
@@ -181,6 +181,8 @@ jobs:
   gpu-ci-flexflow:
     name: Single Machine, Multiple GPUs Tests
     runs-on: self-hosted
+    #skip this time-consuming test for PRs to the inference branch
+    if: ${{ github.event_name != 'pull_request' || github.base_ref != 'inference' }}
     needs: inference-tests
     container:
       image: ghcr.io/flexflow/flexflow-environment-cuda:latest

--- a/inference/incr_decoding/incr_decoding.cc
+++ b/inference/incr_decoding/incr_decoding.cc
@@ -38,7 +38,8 @@ void parse_input_args(char **argv,
                       int argc,
                       FilePaths &paths,
                       ModelType &llm_model_type,
-                      bool &use_full_precision) {
+                      bool &use_full_precision,
+                      bool &verbose) {
   for (int i = 1; i < argc; i++) {
     // llm model type
     if (!strcmp(argv[i], "-llm-model")) {
@@ -85,6 +86,11 @@ void parse_input_args(char **argv,
       use_full_precision = true;
       continue;
     }
+    // verbose logging to stdout
+    if (!strcmp(argv[i], "--verbose")) {
+      verbose = true;
+      continue;
+    }
   }
 }
 
@@ -96,11 +102,13 @@ void FlexFlow::top_level_task(Task const *task,
   FilePaths file_paths;
   ModelType model_type;
   bool use_full_precision = false;
+  bool verbose = false;
 
   InputArgs const &command_args = HighLevelRuntime::get_input_args();
   char **argv = command_args.argv;
   int argc = command_args.argc;
-  parse_input_args(argv, argc, file_paths, model_type, use_full_precision);
+  parse_input_args(
+      argv, argc, file_paths, model_type, use_full_precision, verbose);
 
   assert(model_type != ModelType::UNKNOWN &&
          "Invalid LLM model type passed (or no type was passed).");
@@ -131,7 +139,7 @@ void FlexFlow::top_level_task(Task const *task,
   RequestManager rm((model_type == ModelType::LLAMA)
                         ? (Tokenizer *)sp_tokenizer
                         : (Tokenizer *)opt_tokenizer,
-                    /*verbose*/ false,
+                    /*verbose*/ verbose,
                     file_paths.output_file_path);
   int total_num_requests = 0;
   {

--- a/inference/models/llama.cc
+++ b/inference/models/llama.cc
@@ -215,7 +215,7 @@ void LLAMA::create_llama_model(FFModel &ff,
                             llama_config.dim,
                             llama_config.dim / llama_config.n_heads);
   fileloader.load_weights(&ff, weights_layers);
-  std::cout << "------load wieght finished----------" << std::endl;
+  std::cout << "------load weight finished----------" << std::endl;
 
   // init operators
   im.init_operators_inference(&ff);

--- a/inference/spec_infer/spec_infer.cc
+++ b/inference/spec_infer/spec_infer.cc
@@ -45,7 +45,8 @@ void parse_input_args(char **argv,
                       int argc,
                       FilePaths &paths,
                       ModelTypes &model_types,
-                      bool &use_full_precision) {
+                      bool &use_full_precision,
+                      bool &verbose) {
   for (int i = 1; i < argc; i++) {
     // llm model type
     if (!strcmp(argv[i], "-llm-model")) {
@@ -120,6 +121,11 @@ void parse_input_args(char **argv,
       use_full_precision = true;
       continue;
     }
+    // verbose logging to stdout
+    if (!strcmp(argv[i], "--verbose")) {
+      verbose = true;
+      continue;
+    }
   }
 }
 
@@ -131,11 +137,13 @@ void FlexFlow::top_level_task(Task const *task,
   FilePaths file_paths;
   ModelTypes model_types;
   bool use_full_precision = false;
+  bool verbose = false;
 
   InputArgs const &command_args = HighLevelRuntime::get_input_args();
   char **argv = command_args.argv;
   int argc = command_args.argc;
-  parse_input_args(argv, argc, file_paths, model_types, use_full_precision);
+  parse_input_args(
+      argv, argc, file_paths, model_types, use_full_precision, verbose);
   if (file_paths.ssm_weight_file_paths.size() == 0) {
     assert(false &&
            "SpecInfer needs at least one SSM for speculative inference");
@@ -184,7 +192,7 @@ void FlexFlow::top_level_task(Task const *task,
   RequestManager rm((model_types.llm_model_type == ModelType::LLAMA)
                         ? (Tokenizer *)sp_tokenizer
                         : (Tokenizer *)opt_tokenizer,
-                    /*verbose*/ false,
+                    /*verbose*/ verbose,
                     file_paths.output_file_path);
   int total_num_requests = 0;
   {

--- a/inference/utils/download_llama_weights.py
+++ b/inference/utils/download_llama_weights.py
@@ -2,7 +2,16 @@
 
 import os
 import requests
+import argparse
 from transformers import AutoModelForCausalLM
+
+# You can pass the --use-full-precision flag to use the full-precision weight. By default, we use half precision.
+parser = argparse.ArgumentParser()
+parser.add_argument("--use-full-precision", action="store_true", help="Use full precision")
+args = parser.parse_args()
+if not args.use_full_precision:
+    import torch
+    torch.set_default_tensor_type(torch.HalfTensor)
 
 # Change working dir to folder storing this script
 abspath = os.path.abspath(__file__)
@@ -33,12 +42,12 @@ def convert_hf_model(model, dst_folder):
 
 # Download and convert big model weights
 model = AutoModelForCausalLM.from_pretrained("decapoda-research/llama-7b-hf")
-dst_folder="../weights/llama_7B_weights"
+dst_folder="../weights/llama_7B_weights" if args.use_full_precision else "../weights/llama_7B_weights_half"
 convert_hf_model(model, dst_folder)
 
 # Download and convert small model weights
 model = AutoModelForCausalLM.from_pretrained("JackFram/llama-160m")
-dst_folder="../weights/llama_160M_weights"
+dst_folder="../weights/llama_160M_weights" if args.use_full_precision else "../weights/llama_160M_weights_half"
 convert_hf_model(model, dst_folder)
 
 # Download tokenizer

--- a/src/ops/kernels/rms_norm_kernels.cu
+++ b/src/ops/kernels/rms_norm_kernels.cu
@@ -93,10 +93,11 @@ __global__ void
     long long const index = i * N + j;
     sum += (static_cast<float>(X[index]) * static_cast<float>(X[index]));
   }
-  sum = BlockReduceSum<float>(sum, v_shared); // use BlockReduceSum() to sum X_ij^2
+  sum = BlockReduceSum<float>(sum,
+                              v_shared); // use BlockReduceSum() to sum X_ij^2
 
   if (threadIdx.x == 0) {
-    rms[i] = static_cast<T>(rsqrt((sum / static_cast<float>(N)) + eps));    
+    rms[i] = static_cast<T>(rsqrt((sum / static_cast<float>(N)) + eps));
   }
 }
 
@@ -130,10 +131,7 @@ void forward_kernel(RMSNormMeta const *m,
   int parallelism = m->batch_size * m->in_dim;
   RowwiseRootMeanSquareKernel<T>
       <<<m->batch_size, kCUDABlockReduceNumThreads, 0, stream>>>(
-          m->in_dim,
-          m->eps,
-          input_ptr,
-          static_cast<T *>(m->rms_ptr));
+          m->in_dim, m->eps, input_ptr, static_cast<T *>(m->rms_ptr));
   NormKernel<T><<<m->batch_size, kCUDANumThreads, 0, stream>>>(
       m->in_dim,
       input_ptr,

--- a/src/ops/kernels/softmax.cu
+++ b/src/ops/kernels/softmax.cu
@@ -63,7 +63,6 @@ void forward_kernel_wrapper(SoftmaxMeta const *m,
     log_measure.debug(
         "%s [Softmax] forward time = %.2fms\n", m->op_name, elapsed);
   }
-
 }
 
 template <typename DT>

--- a/src/ops/tree_inc_multihead_self_attention.cu
+++ b/src/ops/tree_inc_multihead_self_attention.cu
@@ -137,7 +137,7 @@ __global__ void update_tree_branch_kv_cache(
         (i / proj_size) % num_tokens_in_branch; // index in the tree branch
     int head_idx = i / (proj_size * num_tokens_in_branch);
 
-    token_idx += processed_tokens_in_batch;     // get index in the whole batch
+    token_idx += processed_tokens_in_batch; // get index in the whole batch
     int qkv_block_size = (qProjSize + kProjSize + vProjSize) *
                          total_tokens_in_batch; // skip over previous heads
     int current_head_block_size =

--- a/src/runtime/request_manager.cc
+++ b/src/runtime/request_manager.cc
@@ -16,6 +16,7 @@
 #include "flexflow/inference.h"
 #include "flexflow/parallel_ops/parallel_op.h"
 #include "flexflow/tokenizers.h"
+#include <iomanip>
 #include <new>
 #include <stdexcept>
 
@@ -146,6 +147,10 @@ BatchConfig RequestManager::prepare_next_batch(BatchConfig const &old_bc,
       if (!output_filepath.empty()) {
         std::ofstream outputFile(output_filepath);
         if (outputFile.is_open()) {
+          outputFile << "end-to-end latency: " << std::fixed
+                     << std::setprecision(3) << total_request_run_time
+                     << std::endl;
+          outputFile << "token IDs: ";
           for (int i = 0; i < request.tokens.size(); i++) {
             outputFile << request.tokens[i];
             if (i < request.tokens.size() - 1) {
@@ -456,6 +461,10 @@ BeamSearchBatchConfig
       if (!output_filepath.empty()) {
         std::ofstream outputFile(output_filepath);
         if (outputFile.is_open()) {
+          outputFile << "end-to-end latency: " << std::fixed
+                     << std::setprecision(3) << total_request_run_time
+                     << std::endl;
+          outputFile << "token IDs: ";
           for (int i = 0; i < request.tokens.size(); i++) {
             outputFile << request.tokens[i];
             if (i < request.tokens.size() - 1) {

--- a/tests/inference/huggingface_inference.py
+++ b/tests/inference/huggingface_inference.py
@@ -1,0 +1,59 @@
+import argparse
+import json
+import os
+from transformers import AutoModelForCausalLM
+from transformers import AutoTokenizer
+
+def main():
+    # Change working dir to folder storing this script
+    abspath = os.path.abspath(__file__)
+    dname = os.path.dirname(abspath)
+    os.chdir(dname)
+    
+    # Parse command line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model-name', type=str, required=True)
+    parser.add_argument('--tokenizer-model-name', type=str, required=True)
+    parser.add_argument('--max-length', type=int, default=128)
+    parser.add_argument('--prompt-file', type=str, required=True)
+    parser.add_argument('--output-file', type=str, required=True)
+    parser.add_argument("--use-full-precision", action="store_true", help="Use full precision")
+    parser.add_argument("--gpu", action="store_true", help="Run on GPU")
+    args = parser.parse_args()
+    # Check if max-length is greater than 0
+    if args.max_length <= 0:
+        print("Error: max-length must be greater than 0.")
+        return
+    # Check if prompt-file exists
+    if not os.path.isfile(args.prompt_file):
+        print(f"Error: {args.prompt_file} does not exist.")
+        return
+    
+    # Read prompt-file into a list of strings
+    with open(args.prompt_file, 'r') as f:
+        try:
+            prompt_list = json.load(f)
+        except json.JSONDecodeError:
+            print(f"Error: Unable to parse {args.prompt_file} as JSON.")
+            return
+    
+    # Set default tensor type depending on argument indicating the float type to use
+    if not args.use_full_precision:
+        import torch
+        torch.set_default_tensor_type(torch.HalfTensor)
+
+    # Run huggingface model
+    device = "cuda" if args.gpu else "cpu"
+    model = AutoModelForCausalLM.from_pretrained(args.model_name).to(device)
+    tokenizer = AutoTokenizer.from_pretrained(args.tokenizer_model_name)
+    with open(args.output_file, 'w') as f:
+        for i, prompt in enumerate(prompt_list):
+            batch = tokenizer(prompt_list, return_tensors="pt", add_special_tokens=True).to(device)
+            generated = model.generate(batch["input_ids"], max_length=args.max_length)
+            out = tokenizer.decode(generated[0])
+            # Write output to file
+            out_str = out if i == (len(prompt_list) - 1) else out + "\n"
+            f.write(out_str)
+
+if __name__ == '__main__':
+    main()

--- a/tests/inference_tests.sh
+++ b/tests/inference_tests.sh
@@ -3,12 +3,7 @@ set -x
 set -e
 
 cleanup() {
-    rm -rf ../inference/prompt ../inference/weights ../inference/tokenizer
-}
-
-copy_embedding_weights(){
-    cp ../inference/weights/opt_6B_weights/embed_tokens_weight ../inference/weights/opt_6B_weights/embed_tokens_weight_lm_head
-    cp ../inference/weights/opt_125M_weights/embed_tokens_weight ../inference/weights/opt_125M_weights/embed_tokens_weight_lm_head
+    rm -rf ../inference/prompt ../inference/weights ../inference/tokenizer ../inference/output
 }
 
 # Cd into directory holding this script
@@ -20,12 +15,11 @@ cleanup
 # Update the transformers library to support the LLAMA model
 pip3 install --upgrade transformers
 
-# Download the weights
+# Download the weights in both half and full precision
 python3 ../inference/utils/download_llama_weights.py
+python3 ../inference/utils/download_llama_weights.py --use-full-precision
 python3 ../inference/utils/download_opt_weights.py
-
-# because huggingface reuse a weight in embedding and final linear
-copy_embedding_weights
+python3 ../inference/utils/download_opt_weights.py --use-full-precision
 
 # Create test prompt file
 mkdir -p ../inference/prompt
@@ -40,9 +34,13 @@ mkdir -p ../inference/output
 
 # LLAMA
 ../build/inference/spec_infer/spec_infer -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 --use-full-precision -llm-model llama -llm-weight ../inference/weights/llama_7B_weights/ -llm-config ../inference/models/configs/llama_7B.json -ssm-model llama -ssm-weight ../inference/weights/llama_160M_weights/ -ssm-config ../inference/models/configs/llama_160M.json -tokenizer ../inference/tokenizer/tokenizer.model -prompt ../inference/prompt/test.json -output-file ../inference/output/spec_inference_llama.txt
+# LLAMA (half precision)
+../build/inference/spec_infer/spec_infer -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 -llm-model llama -llm-weight ../inference/weights/llama_7B_weights_half/ -llm-config ../inference/models/configs/llama_7B.json -ssm-model llama -ssm-weight ../inference/weights/llama_160M_weights_half/ -ssm-config ../inference/models/configs/llama_160M.json -tokenizer ../inference/tokenizer/tokenizer.model -prompt ../inference/prompt/test.json -output-file ../inference/output/spec_inference_llama_half.txt
 
 # OPT
 ../build/inference/spec_infer/spec_infer -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 --use-full-precision -llm-model opt -llm-weight ../inference/weights/opt_6B_weights/ -llm-config ../inference/models/configs/opt_6B.json -ssm-model opt -ssm-weight ../inference/weights/opt_125M_weights/ -ssm-config ../inference/models/configs/opt_125M.json -tokenizer ../inference/tokenizer/ -prompt ../inference/prompt/test.json -output-file ../inference/output/spec_inference_opt.txt
+# OPT (half precision)
+../build/inference/spec_infer/spec_infer -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 -llm-model opt -llm-weight ../inference/weights/opt_6B_weights_half/ -llm-config ../inference/models/configs/opt_6B.json -ssm-model opt -ssm-weight ../inference/weights/opt_125M_weights_half/ -ssm-config ../inference/models/configs/opt_125M.json -tokenizer ../inference/tokenizer/ -prompt ../inference/prompt/test.json -output-file ../inference/output/spec_inference_opt_half.txt
 
 ###############################################################################################
 ############################ Incremental decoding tests #######################################
@@ -50,24 +48,104 @@ mkdir -p ../inference/output
 
 # LLAMA (small model)
 ../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 --use-full-precision -llm-model llama -llm-weight ../inference/weights/llama_160M_weights/ -llm-config ../inference/models/configs/llama_160M.json -tokenizer ../inference/tokenizer/tokenizer.model -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_llama_160M.txt
+# LLAMA (small model, half precision)
+../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 -llm-model llama -llm-weight ../inference/weights/llama_160M_weights_half/ -llm-config ../inference/models/configs/llama_160M.json -tokenizer ../inference/tokenizer/tokenizer.model -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_llama_160M_half.txt
 
 # LLAMA (big model)
 ../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 --use-full-precision -llm-model llama -llm-weight ../inference/weights/llama_7B_weights/ -llm-config ../inference/models/configs/llama_7B.json -tokenizer ../inference/tokenizer/tokenizer.model -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_llama_7B.txt
+# LLAMA (big model, half precision)
+../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 -llm-model llama -llm-weight ../inference/weights/llama_7B_weights_half/ -llm-config ../inference/models/configs/llama_7B.json -tokenizer ../inference/tokenizer/tokenizer.model -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_llama_7B_half.txt
 
 # OPT (small model)
 ../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 --use-full-precision -llm-model opt -llm-weight ../inference/weights/opt_125M_weights/ -llm-config ../inference/models/configs/opt_125M.json -tokenizer ../inference/tokenizer/ -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_opt_125M.txt
+# OPT (small model, half precision)
+../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 -llm-model opt -llm-weight ../inference/weights/opt_125M_weights_half/ -llm-config ../inference/models/configs/opt_125M.json -tokenizer ../inference/tokenizer/ -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_opt_125M_half.txt
 
 # OPT (big model)
 ../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 --use-full-precision -llm-model opt -llm-weight ../inference/weights/opt_6B_weights/ -llm-config ../inference/models/configs/opt_6B.json -tokenizer ../inference/tokenizer/ -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_opt_6B.txt
+# OPT (big model, half precision)
+../build/inference/incr_decoding/incr_decoding -ll:gpu 4 -ll:fsize 14000 -ll:zsize 30000 -llm-model opt -llm-weight ../inference/weights/opt_6B_weights_half/ -llm-config ../inference/models/configs/opt_6B.json -tokenizer ../inference/tokenizer/ -prompt ../inference/prompt/test.json -output-file ../inference/output/incr_decoding_opt_6B_half.txt
 
 
 ###############################################################################################
-################################## Alignment tests ############################################
+############################### Alignment and Speed tests #####################################
 ###############################################################################################
 
-diff ../inference/output/incr_decoding_llama_7B.txt ../inference/output/spec_inference_llama.txt
-diff ../inference/output/incr_decoding_opt_6B.txt ../inference/output/spec_inference_opt.txt
+############ Alignment between speculative inference and incremental decoding #################
+# Full precision
+diff <(tail -n +2 "../inference/output/incr_decoding_llama_7B.txt") <(tail -n +2 "../inference/output/spec_inference_llama.txt")
+diff <(tail -n +2 "../inference/output/incr_decoding_opt_6B.txt") <(tail -n +2 "../inference/output/spec_inference_opt.txt")
+# Half precision
+#diff <(tail -n +2 "../inference/output/incr_decoding_llama_7B_half.txt") <(tail -n +2 "../inference/output/spec_inference_llama_half.txt")
+#diff <(tail -n +2 "../inference/output/incr_decoding_opt_6B_half.txt" ) <(tail -n +2 "../inference/output/spec_inference_opt_half.txt")
 
+# Speed test: speculative inference should be at very least 1.5x faster than incremental decoding
+function compare_speed_spec_infer_incr_decoding {
+    local incrDec_file="$1"
+    local specInf_file="$2"
+
+    # Read the float numbers from the first line of the files
+    incrDec=$(sed -n '1 s/end-to-end latency: \(.*\)/\1/p' "$incrDec_file")
+    specInf=$(sed -n '1 s/end-to-end latency: \(.*\)/\1/p' "$specInf_file")
+
+    if ! command -v bc &> /dev/null; then
+        echo "bc is not installed. Installing..."
+        sudo apt-get install -y bc
+    fi
+    
+    # Perform the comparison
+    threshold=$(bc <<< "$specInf * 1.5")
+    if (( $(echo "$incrDec >= $threshold" | bc -l) )); then
+        #echo "The latency in $specInf_file is at least 1.5x smaller than the latency from $incrDec_file."
+        :
+    else
+        echo "Error: The latency in $specInf_file is not at least 1.5x smaller than the latency in $incrDec_file!"
+        exit 1
+    fi
+}
+# Full precision
+compare_speed_spec_infer_incr_decoding "../inference/output/incr_decoding_llama_7B.txt" "../inference/output/spec_inference_llama.txt"
+compare_speed_spec_infer_incr_decoding "../inference/output/incr_decoding_opt_6B.txt" "../inference/output/spec_inference_opt.txt"
+# Half precision
+#compare_speed_spec_infer_incr_decoding "../inference/output/incr_decoding_llama_7B_half.txt" "../inference/output/spec_inference_llama_half.txt"
+#compare_speed_spec_infer_incr_decoding "../inference/output/incr_decoding_opt_6B_half.txt" "../inference/output/spec_inference_opt_half.txt"
+
+######################### Alignment tests with HuggingFace ####################################
+pip3 install protobuf==3.20.3
+
+# LLAMA (small model, full precision)
+python3 ./inference/huggingface_inference.py --model-name "JackFram/llama-160m" --tokenizer-model-name "JackFram/llama-160m" --use-full-precision --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_llama_160M.txt" --gpu
+
+# LLAMA (small model, half precision)
+python3 ./inference/huggingface_inference.py --model-name "JackFram/llama-160m" --tokenizer-model-name "JackFram/llama-160m" --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_llama_160M_half.txt" --gpu
+
+# LLAMA (big model, full precision)
+python3 ./inference/huggingface_inference.py --model-name "decapoda-research/llama-7b-hf" --tokenizer-model-name "JackFram/llama-160m" --use-full-precision --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_llama_7B.txt"
+
+# LLAMA (big model, half precision)
+python3 ./inference/huggingface_inference.py --model-name "decapoda-research/llama-7b-hf" --tokenizer-model-name "JackFram/llama-160m" --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_llama_7B_half.txt" --gpu
+
+# OPT (small model, full precision)
+python3 ./inference/huggingface_inference.py --model-name "facebook/opt-125m" --tokenizer-model-name "facebook/opt-125m" --use-full-precision --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_opt_125M.txt" --gpu --max-length 127
+
+# OPT (small model, half precision)
+python3 ./inference/huggingface_inference.py --model-name "facebook/opt-125m" --tokenizer-model-name "facebook/opt-125m" --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_opt_125M_half.txt" --gpu --max-length 127
+
+# OPT (big model, full precision)
+#python3 ./inference/huggingface_inference.py --model-name "facebook/opt-6.7b" --tokenizer-model-name "facebook/opt-6.7b" --use-full-precision --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_opt_6B.txt" --max-length 127
+
+# OPT (big model, half precision)
+#python3 ./inference/huggingface_inference.py --model-name "facebook/opt-6.7b" --tokenizer-model-name "facebook/opt-6.7b" --prompt-file "../../inference/prompt/test.json" --output-file "../../inference/output/huggingface_opt_6B_half.txt" --gpu --max-length 127
+
+diff <(tail -n +2 "../inference/output/huggingface_llama_160M.txt") <(tail -n +4 "../inference/output/incr_decoding_llama_160M.txt")
+diff <(tail -n +2 "../inference/output/huggingface_llama_160M_half.txt") <(tail -n +4 "../inference/output/incr_decoding_llama_160M_half.txt")
+diff <(tail -n +2 "../inference/output/huggingface_llama_7B.txt") <(tail -n +4 "../inference/output/incr_decoding_llama_7B.txt")
+diff <(tail -n +2 "../inference/output/huggingface_llama_7B_half.txt") <(tail -n +4 "../inference/output/incr_decoding_llama_7B_half.txt")
+
+diff <(tail -n +2 "../inference/output/huggingface_opt_125M.txt") <(tail -n +4 "../inference/output/incr_decoding_opt_125M.txt")
+diff <(tail -n +2 "../inference/output/huggingface_opt_125M_half.txt") <(tail -n +4 "../inference/output/incr_decoding_opt_125M_half.txt")
+#diff <(tail -n +2 "../inference/output/huggingface_opt_6B.txt") <(tail -n +4 "../inference/output/incr_decoding_opt_6B.txt")
+#diff <(tail -n +2 "../inference/output/huggingface_opt_6B_half.txt") <(tail -n +4 "../inference/output/incr_decoding_opt_6B_half.txt")
 
 ###############################################################################################
 ###################################### Cleanup ################################################


### PR DESCRIPTION
…d tests (#749)

* add support for downloading mixed precision llama/opt weights

* fix

* update test script to also run half precision tests

* disable workflow for inference PRs

* add verbose option

* linting

* copy opt weights in download weights script

* add alignment tests with huggingface (llama)

* fix, add diff to test script

* fix

* add opt tests

* comment out tests not passing

* add e2e latency to output files

* add speed tests

* shellcheck

* shellcheck

* fix

* fix

* linting

* fix

**Description of changes:**



**Related Issues:**

Linked Issues:
- Issue #

Issues closed by this PR:
- Closes #

**Before merging:**

- [ ] Did you update the [flexflow-third-party](https://github.com/flexflow/flexflow-third-party) repo, if modifying any of the Cmake files, the build configs, or the submodules?
